### PR TITLE
ColumnIndexes function is now deterministic

### DIFF
--- a/internal/spreadsheet.go
+++ b/internal/spreadsheet.go
@@ -14,17 +14,20 @@ func Headers(files []string) [][]string {
 // ColumnIndexes returns the matching column index of a column position
 func ColumnIndexes(headers []string, want []string) []int {
 	indexMap := make(map[string]int)
-	wantSet := make(map[string]bool)
+	wantMap := make(map[string]bool)
 	for i, header := range headers {
 		indexMap[header] = i
 	}
-	for _, w := range want {
-		wantSet[w] = true
-	}
 	var indexes []int
-	for w := range wantSet {
-		if index, ok := indexMap[w]; ok {
+	added := make(map[int]bool)
+	for _, w := range want {
+		if wantMap[w] {
+			continue
+		}
+		wantMap[w] = true
+		if index, ok := indexMap[w]; ok && !added[index] {
 			indexes = append(indexes, index)
+			added[index] = true
 		}
 	}
 	return indexes


### PR DESCRIPTION
To ensure that the returned indexes are unique and in the same order as the elements in want, we can modify the implementation to keep track of the already added indexes in a set data structure.

In this implementation, we use a separate map added to keep track of the already added indexes. For each element in want, we first check if it has already been added to the result slice. If it has, we skip it. Otherwise, we check if its index exists in indexMap and has not already been added to the result slice. If both conditions are met, we append the index to the result slice and mark it as added in the added map.

This implementation should return the indexes in the same order as the elements in want, while also ensuring that the indexes are unique. It should have a time complexity of O(m+n), where m is the length of headers and n is the length of want.